### PR TITLE
WIP: Support wpull as more effective alternative to wget

### DIFF
--- a/ghost_domains.py
+++ b/ghost_domains.py
@@ -41,15 +41,17 @@ class GhostDomainsPlugin(WpullPlugin):
             return True
         return False
 
-    @event(PluginFunctions.get_urls)
+    # to enable these stubs, uncomment the @event decorator
+
+    # @event(PluginFunctions.get_urls)
     def my_get_urls(self, item_session: ItemSession):
         self.logger.debug(f'get_urls: {item_session.request.url}')
 
-    @event(PluginFunctions.queued_url)
+    # @event(PluginFunctions.queued_url)
     def my_queued_url(self, url_info: wpull.url.URLInfo):
         self.logger.debug(f'queued_url: {url_info.url}')
 
-    @event(PluginFunctions.dequeued_url)
+    # @event(PluginFunctions.dequeued_url)
     def my_dequeued_url(self, url_info: wpull.url.URLInfo, record_info: wpull.pipeline.item.URLRecord):
         self.logger.debug(f'dequeued_url: {url_info.url} -> {record_info.url}')
 

--- a/ghost_domains.py
+++ b/ghost_domains.py
@@ -32,6 +32,9 @@ class GhostDomainsPlugin(WpullPlugin):
             print(f'accept check: {item_session.request.url} -> {adjusted_url}')
             return False
         elif item_session.request.url.startswith(SOURCE_BASE):
+            if item_session.request.url.startswith(SOURCE_BASE + 'ghost/'):
+                print(f'accept check: denying ghost admin interface: {item_session.request.url}')
+                return False
             return True
         return False
 

--- a/ghost_domains.py
+++ b/ghost_domains.py
@@ -9,12 +9,15 @@ from wpull.application.plugin import WpullPlugin, PluginFunctions, hook, event
 from wpull.protocol.abstract.request import BaseResponse
 from wpull.pipeline.session import ItemSession
 import wpull
+import logging
 
 # FIXME: pass these as options:
 SOURCE_BASE = 'http://localhost:2368/'
 PRODUCTION_BASE = 'https://ghost.example.com/'
 
 class GhostDomainsPlugin(WpullPlugin):
+    logger = logging.getLogger('wpull.plugin.ghost_domains') # this has to start with wpull or the logging will be filtered
+
     def activate(self):
         super().activate()
         import pprint, os, sys
@@ -29,26 +32,26 @@ class GhostDomainsPlugin(WpullPlugin):
         if item_session.request.url.startswith(PRODUCTION_BASE):
             adjusted_url = item_session.request.url.replace(PRODUCTION_BASE, SOURCE_BASE, 1)
             item_session.add_child_url(adjusted_url)
-            print(f'accept check: {item_session.request.url} -> {adjusted_url}')
+            self.logger.info(f'Production domain remap: rather than retrieving {item_session.request.url}, will retrieve {adjusted_url}')
             return False
         elif item_session.request.url.startswith(SOURCE_BASE):
             if item_session.request.url.startswith(SOURCE_BASE + 'ghost/'):
-                print(f'accept check: denying ghost admin interface: {item_session.request.url}')
+                self.logger.info(f'Not retrieving ghost admin interface url: {item_session.request.url}')
                 return False
             return True
         return False
 
     @event(PluginFunctions.get_urls)
     def my_get_urls(self, item_session: ItemSession):
-        print(f'get_urls: {item_session.request.url}')
+        self.logger.debug(f'get_urls: {item_session.request.url}')
 
     @event(PluginFunctions.queued_url)
     def my_queued_url(self, url_info: wpull.url.URLInfo):
-        print(f'queued_url: {url_info.url}')
+        self.logger.debug(f'queued_url: {url_info.url}')
 
     @event(PluginFunctions.dequeued_url)
     def my_dequeued_url(self, url_info: wpull.url.URLInfo, record_info: wpull.pipeline.item.URLRecord):
-        print(f'dequeued_url: {url_info.url} -> {record_info.url}')
+        self.logger.debug(f'dequeued_url: {url_info.url} -> {record_info.url}')
 
 
 if __name__ == '__main__':

--- a/ghost_domains.py
+++ b/ghost_domains.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 """This is a plugin for wpull that intelligently adjusts domains when mirroring a ghost site for static serving
-It is intended for use with the --plugin-script option for wpull, not to be run as a main program"""
+It is intended for use with the --plugin-script option for wpull, not to be run as a main program
+Note that the SOURCE_DOMAIN and PRODUCTION_DOMAIN values must be passed to wpull as environment variables"""
 
 import re
 from wpull.application.hook import Actions
@@ -10,32 +11,37 @@ from wpull.protocol.abstract.request import BaseResponse
 from wpull.pipeline.session import ItemSession
 import wpull
 import logging
-
-# FIXME: pass these as options:
-SOURCE_BASE = 'http://localhost:2368/'
-PRODUCTION_BASE = 'https://ghost.example.com/'
+import os
 
 class GhostDomainsPlugin(WpullPlugin):
     logger = logging.getLogger('wpull.plugin.ghost_domains') # this has to start with wpull or the logging will be filtered
+    SOURCE_DOMAIN = os.environ.get('SOURCE_DOMAIN')
+    PRODUCTION_DOMAIN = os.environ.get('PRODUCTION_DOMAIN')
 
     def activate(self):
         super().activate()
-        import pprint, os, sys
-        pprint.pprint(os.environ)
-        pprint.pprint(sys.argv)
+        if not self.SOURCE_DOMAIN:
+            self.logger.warn(f"Did not find SOURCE_DOMAIN in environment; will not remap ghost production urls")
+        if not self.PRODUCTION_DOMAIN:
+            self.logger.warn(f"Did not find PRODUCTION_DOMAIN in environment; will not remap ghost production urls")
+        if self.SOURCE_DOMAIN and self.PRODUCTION_DOMAIN:
+            self.logger.info(f"Will remap {self.PRODUCTION_DOMAIN} to {self.SOURCE_DOMAIN}")
 
     def deactivate(self):
         super().deactivate()
 
     @hook(PluginFunctions.accept_url)
     def my_accept_func(self, item_session: ItemSession, verdict: bool, reasons: dict) -> bool:
-        if item_session.request.url.startswith(PRODUCTION_BASE):
-            adjusted_url = item_session.request.url.replace(PRODUCTION_BASE, SOURCE_BASE, 1)
+        if not self.PRODUCTION_DOMAIN or not self.SOURCE_DOMAIN:
+            # this means that this is not properly set up in order to be able to filter domains
+            return True
+        if item_session.request.url.startswith(self.PRODUCTION_DOMAIN):
+            adjusted_url = item_session.request.url.replace(self.PRODUCTION_DOMAIN, self.SOURCE_DOMAIN, 1)
             item_session.add_child_url(adjusted_url)
             self.logger.info(f'Production domain remap: rather than retrieving {item_session.request.url}, will retrieve {adjusted_url}')
             return False
-        elif item_session.request.url.startswith(SOURCE_BASE):
-            if item_session.request.url.startswith(SOURCE_BASE + 'ghost/'):
+        elif item_session.request.url.startswith(self.SOURCE_DOMAIN):
+            if item_session.request.url.startswith(self.SOURCE_DOMAIN.rstrip('/') + '/ghost/'):
                 self.logger.info(f'Not retrieving ghost admin interface url: {item_session.request.url}')
                 return False
             return True

--- a/ghost_domains.py
+++ b/ghost_domains.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+"""This is a plugin for wpull that intelligently adjusts domains when mirroring a ghost site for static serving
+It is intended for use with the --plugin-script option for wpull, not to be run as a main program"""
+
+import re
+from wpull.application.hook import Actions
+from wpull.application.plugin import WpullPlugin, PluginFunctions, hook, event
+from wpull.protocol.abstract.request import BaseResponse
+from wpull.pipeline.session import ItemSession
+import wpull
+
+# FIXME: pass these as options:
+SOURCE_BASE = 'http://localhost:2368/'
+PRODUCTION_BASE = 'https://ghost.example.com/'
+
+class GhostDomainsPlugin(WpullPlugin):
+    def activate(self):
+        super().activate()
+        import pprint, os, sys
+        pprint.pprint(os.environ)
+        pprint.pprint(sys.argv)
+
+    def deactivate(self):
+        super().deactivate()
+
+    @hook(PluginFunctions.accept_url)
+    def my_accept_func(self, item_session: ItemSession, verdict: bool, reasons: dict) -> bool:
+        if item_session.request.url.startswith(PRODUCTION_BASE):
+            adjusted_url = item_session.request.url.replace(PRODUCTION_BASE, SOURCE_BASE, 1)
+            item_session.add_child_url(adjusted_url)
+            print(f'accept check: {item_session.request.url} -> {adjusted_url}')
+            return False
+        elif item_session.request.url.startswith(SOURCE_BASE):
+            return True
+        return False
+
+    @event(PluginFunctions.get_urls)
+    def my_get_urls(self, item_session: ItemSession):
+        print(f'get_urls: {item_session.request.url}')
+
+    @event(PluginFunctions.queued_url)
+    def my_queued_url(self, url_info: wpull.url.URLInfo):
+        print(f'queued_url: {url_info.url}')
+
+    @event(PluginFunctions.dequeued_url)
+    def my_dequeued_url(self, url_info: wpull.url.URLInfo, record_info: wpull.pipeline.item.URLRecord):
+        print(f'dequeued_url: {url_info.url} -> {record_info.url}')
+
+
+if __name__ == '__main__':
+    print(__doc__)
+

--- a/src/commands/generateStaticSite.js
+++ b/src/commands/generateStaticSite.js
@@ -21,7 +21,10 @@ const generateStaticSite = async () => {
      */
     await mkdirp(`${OPTIONS.STATIC_DIRECTORY}/content`);
 
-    const urls = [
+    const urls = OPTIONS.MIRROR_COMMAND === 'wpull' ? [
+      // this simply adds extra requirements to the same wpull invocation as the main site
+      `${OPTIONS.SOURCE_DOMAIN}/ ${OPTIONS.SOURCE_DOMAIN}/robots.txt ${OPTIONS.SOURCE_DOMAIN}/404 ${OPTIONS.SOURCE_DOMAIN}/sitemap.xsl ${OPTIONS.SOURCE_DOMAIN}/public/ghost.css`,
+    ] : [
       `${OPTIONS.SOURCE_DOMAIN}/`,
       `${OPTIONS.SOURCE_DOMAIN}/sitemap.xsl`,
       `${OPTIONS.SOURCE_DOMAIN}/sitemap.xml`,
@@ -32,9 +35,10 @@ const generateStaticSite = async () => {
       `${OPTIONS.SOURCE_DOMAIN}/public/404-ghost@2x.png`,
       `${OPTIONS.SOURCE_DOMAIN}/public/404-ghost@2x.png`,
       `${OPTIONS.SOURCE_DOMAIN}/assets/built/screen.css`,
-	  `${OPTIONS.SOURCE_DOMAIN}/assets/built/casper.js`,
-	  `${OPTIONS.SOURCE_DOMAIN}/assets/built/global.css`,
+      `${OPTIONS.SOURCE_DOMAIN}/assets/built/casper.js`,
+      `${OPTIONS.SOURCE_DOMAIN}/assets/built/global.css`,
     ];
+  
 
     if(OPTIONS.SOURCE_DOMAIN.startsWith("http://127.0.0.1")){
     	console.warn("\x1b[33m%s\x1b[0m", "[WARNING]: You specified \"127.0.0.1\" as the host for your site, but the ghost default host is \"localhost\". If your \"--domain\" does not exactly match the value of \"url\" in your ghost \"config.development.json\" or \"config.json\", gssg will fail!")

--- a/src/constants/OPTIONS.js
+++ b/src/constants/OPTIONS.js
@@ -18,6 +18,8 @@ const PRODUCTION_DOMAIN = (argv.productionDomain || argv.url || SOURCE_DOMAIN).r
 const IGNORE_ABSOLUTE_PATHS = argv.ignoreAbsolutePaths || false;
 const STATIC_DIRECTORY = argv.dest || 'static';
 const SAVE_AS_REFERER = argv.saveAsReferer || false;
+const USE_WPULL = argv.useWpull || false;
+const MIRROR_COMMAND = USE_WPULL ? 'wpull' : 'wget';
 
 const shouldShowProgress = () => {
   if (argv.silent) {
@@ -25,7 +27,7 @@ const shouldShowProgress = () => {
   }
 
   const showProgressHelpText = execSync(
-    'wget --help | grep "show-progress" || true',
+    `${MIRROR_COMMAND} --help | grep "show-progress" || true`,
   ).toString();
 
   return `${showProgressHelpText}`.includes('show-progress');
@@ -43,10 +45,12 @@ const OPTIONS = {
   SOURCE_DOMAIN,
   // This is the --domain flag without http:// or https://
   SOURCE_DOMAIN_WITHOUT_PROTOCOL: SOURCE_DOMAIN.replace(/^https?:\/\//i, ''),
+  SOURCE_DOMAIN_PLAIN: SOURCE_DOMAIN.replace(/^https?:\/\//i, '').replace(/:[0-9]+$/, ''),
   // This is the --url flag
   PRODUCTION_DOMAIN,
   // This is the --url flag without http:// or https://
   PRODUCTION_DOMAIN_WITHOUT_PROTOCOL: PRODUCTION_DOMAIN.replace(/^https?:\/\//i, ''),
+  PRODUCTION_DOMAIN_PLAIN: PRODUCTION_DOMAIN.replace(/^https?:\/\//i, '').replace(/:[0-9]+$/, ''),
   // The --silent flag determines if we should show the progress bar or not
   SHOW_PROGRESS_BAR: shouldShowProgress()
     ? '--show-progress '
@@ -56,6 +60,8 @@ const OPTIONS = {
   // --save-as-referer flag will save redirected assets using the
   // original url path instead of the redirected destination url
   SAVE_AS_REFERER,
+  MIRROR_COMMAND,
+  PLUGIN_SCRIPT: path.join(path.dirname(path.dirname(__dirname)), 'ghost_domains.py'),
 };
 
 module.exports = OPTIONS;

--- a/src/helpers/crawlPageAsyncHelper/crawlPageAsyncHelper.js
+++ b/src/helpers/crawlPageAsyncHelper/crawlPageAsyncHelper.js
@@ -4,7 +4,7 @@ const OPTIONS = require('../../constants/OPTIONS');
 
 const contentOnError = () => {
   const contentOnErrorHelpText = execSync(
-    'wget --help | grep "content-on-error" || true',
+    `${OPTIONS.MIRROR_COMMAND} --help | grep "content-on-error" || true`,
   ).toString();
 
   return `${contentOnErrorHelpText}`
@@ -27,12 +27,14 @@ const crawlPageAsyncHelper = (
   url,
   callback = () => {},
 ) => {
-  const wgetCommand = `wget -q ${OPTIONS.SHOW_PROGRESS_BAR}--recursive `
+  const wgetCommand = `${OPTIONS.MIRROR_COMMAND} -v ${OPTIONS.SHOW_PROGRESS_BAR}--recursive `
+    + `${OPTIONS.X_FORWARDED_PROTO}`
     + '--timestamping '
     + '--page-requisites '
     + '--no-parent '
     + '--no-host-directories '
     + '--restrict-file-name=unix '
+    + ((OPTIONS.MIRROR_COMMAND === 'wpull') ? `--plugin-script ${OPTIONS.PLUGIN_SCRIPT} ` : '')
     + `--directory-prefix ${OPTIONS.STATIC_DIRECTORY} ${contentOnError()} `
     + `${saveAsReferer()}`
     + `${url}`;

--- a/src/helpers/crawlPageAsyncHelper/crawlPageAsyncHelper.js
+++ b/src/helpers/crawlPageAsyncHelper/crawlPageAsyncHelper.js
@@ -34,6 +34,8 @@ const crawlPageAsyncHelper = (
     + '--no-parent '
     + '--no-host-directories '
     + '--restrict-file-name=unix '
+    + ((OPTIONS.MIRROR_COMMAND === 'wpull') ? '--no-robots ' : '')
+    + ((OPTIONS.MIRROR_COMMAND === 'wpull') ? '--sitemaps ' : '')
     + ((OPTIONS.MIRROR_COMMAND === 'wpull') ? `--plugin-script ${OPTIONS.PLUGIN_SCRIPT} ` : '')
     + `--directory-prefix ${OPTIONS.STATIC_DIRECTORY} ${contentOnError()} `
     + `${saveAsReferer()}`

--- a/src/helpers/crawlPageHelper/crawlPageHelper.js
+++ b/src/helpers/crawlPageHelper/crawlPageHelper.js
@@ -42,9 +42,11 @@ const crawlPageHelper = (url) => {
 
   try {
     console.log(`Fetching: ${url}`);
+    // the SOURCE_DOMAIN and PRODUCTION_DOMAIN are passed to the wpull ghost_domains plugin using environment variables
+    const env = { ...process.env, SOURCE_DOMAIN: OPTIONS.SOURCE_DOMAIN, PRODUCTION_DOMAIN: OPTIONS.PRODUCTION_DOMAIN};
     execSync(
       wgetCommand,
-      { stdio: 'inherit' },
+      { env, stdio: 'inherit' },
     );
 
     crawlHistory.add(url);

--- a/src/helpers/crawlPageHelper/crawlPageHelper.js
+++ b/src/helpers/crawlPageHelper/crawlPageHelper.js
@@ -6,7 +6,7 @@ const crawlHistory = new Set();
 
 const contentOnError = () => {
   const contentOnErrorHelpText = execSync(
-    'wget --help | grep "content-on-error" || true',
+    `${OPTIONS.MIRROR_COMMAND} --help | grep "content-on-error" || true`,
   ).toString();
 
   return `${contentOnErrorHelpText}`
@@ -26,12 +26,14 @@ const crawlPageHelper = (url) => {
   if (crawlHistory.has(url)) {
     return;
   }
-  const wgetCommand = `wget -q ${OPTIONS.SHOW_PROGRESS_BAR}--recursive `
+  const wgetCommand = `${OPTIONS.MIRROR_COMMAND} -q ${OPTIONS.SHOW_PROGRESS_BAR}--recursive `
+    + `${OPTIONS.X_FORWARDED_PROTO}`
     + '--timestamping '
     + '--page-requisites '
     + '--no-parent '
     + '--no-host-directories '
     + '--restrict-file-name=unix '
+    + ((OPTIONS.MIRROR_COMMAND === 'wpull') ? `--plugin-script ${OPTIONS.PLUGIN_SCRIPT} ` : '')
     + `--directory-prefix ${OPTIONS.STATIC_DIRECTORY} ${contentOnError()} `
     + `${saveAsReferer()}`
     + `${url}`;

--- a/src/helpers/crawlPageHelper/crawlPageHelper.js
+++ b/src/helpers/crawlPageHelper/crawlPageHelper.js
@@ -33,6 +33,8 @@ const crawlPageHelper = (url) => {
     + '--no-parent '
     + '--no-host-directories '
     + '--restrict-file-name=unix '
+    + ((OPTIONS.MIRROR_COMMAND === 'wpull') ? '--no-robots ' : '')
+    + ((OPTIONS.MIRROR_COMMAND === 'wpull') ? '--sitemaps ' : '')
     + ((OPTIONS.MIRROR_COMMAND === 'wpull') ? `--plugin-script ${OPTIONS.PLUGIN_SCRIPT} ` : '')
     + `--directory-prefix ${OPTIONS.STATIC_DIRECTORY} ${contentOnError()} `
     + `${saveAsReferer()}`


### PR DESCRIPTION
This is a work-in-progress effort, which I'd appreciate feedback on.

In my testing of ghost-static-site-generator on an out-of-the-box ghost setup, I found that certain URLs weren't retrieved because they were referred to using the production domain name (notably `/about/`)
This is actually tricky to correct using wget without some complicated work to first identify the URLs for another domain and then retrieve them as well

My solution here is to use wpull as an alternative to wget. This is a Python reimplementation for wget focused on mirroring,
which supports plugins to adjust the process. It may not be for everybody, but it certainly proved to be quite effective for this use case.

_Note:_ The [original wpull](https://github.com/ArchiveTeam/wpull) is not maintained any more, so I've been using the [grab-site fork](https://github.com/ArchiveTeam/ludios_wpull) which is in active development and has a [recent release 5.0.3]( https://github.com/ArchiveTeam/ludios_wpull/releases/tag/5.0.3). The [original docs](https://wpull.readthedocs.io/en/master/) are generally still applicable.

In order to install wpull, I have the following commands in my docker file, which enables building the package:
```bash
apk add --no-cache bash python3 py3-pip py3-pkgconfig python3-dev gcc musl-dev linux-headers pkgconfig libxml2-dev 
pip install --root-user-action=ignore --break-system-packages git+https://github.com/ArchiveTeam/ludios_wpull@5.0.3
```
It would obviously be more ideal if a package were directly available

In testing, I found that this is a little slower than wget (2 seconds instead of less than 1 to retrieve a site), but retrieves the site more accurately - with less parameters it finds more of the valid files, and there's less need to add things to the list of items to retrieve.